### PR TITLE
Add GDI as supported file extension for conversion

### DIFF
--- a/tochd.py
+++ b/tochd.py
@@ -26,7 +26,7 @@ def APP(var=None):
 
 # Test if the path is an iso file.
 def is_iso(path=None):
-    ext = ['iso', 'cue']
+    ext = ['iso', 'cue', 'gdi']
     if path is None:
         return ext
     suffix = path.suffix.lower().lstrip('.')


### PR DESCRIPTION
chdman supports the conversion of GDI files, a format used by Sega Dreamcast emulators.  Adding it to the list of supported ISO file extensions is enough to enable conversion of GDI files to CHD.