### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,7 +77,7 @@ Note: We are jumping over v0.11 and combine it with next version v0.12.
 
 - changed: when multithreading with option `-p`, the stdout and statistics from
   invoked `7z` and `chdman` commands are no longer hidden anymore, only the
-  progress bar and stderr stream are hidden, use option `-q` to supress any
+  progress bar and stderr stream are hidden, use option `-q` to suppress any
   output from these commands (how it worked previously)
 
 ## v0.6 - March 25, 2022 - Complete rewrite
@@ -90,7 +90,7 @@ Note: We are jumping over v0.11 and combine it with next version v0.12.
   current job process and continue with the next one in list
 - changed: more reliable in removing temporary folders and unfinished files,
   even with multithreading enabled and on `Ctrl+c` signal
-- new: option `-E` to change behavior of `Ctrl+c` to immadiately stop execution
+- new: option `-E` to change behavior of `Ctrl+c` to immediately stop execution
   of entire script, which may leave temporary folders and unfinished files on
   the system
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ threads with option `-t` (short for `--threads`).
 ### Automatic renaming output files based on archive filename
 
 - Sometimes .cue or .iso files found in an archive have a different name than the
-  archive filename itself. Sometimes one of them lack important informations and
+  archive filename itself. Sometimes one of them lack important information and
   you need to determine which of them is "correct". In example translations could
   have important information encoded in the filename of the .cue, which would be
   lost, as the .CHD file is automatically renamed to match the .zip or .7z

--- a/tochd.py
+++ b/tochd.py
@@ -666,7 +666,7 @@ def parse_arguments(args: list[str] | None = None) -> Argparse:
         default=False,
         action="store_true",
         help=(
-            "supress output from external programs, print job messages "
+            "suppress output from external programs, print job messages "
             "only, automate user input when possible"
         ),
     )


### PR DESCRIPTION
Found via `codespell -H`